### PR TITLE
Update wording for Info.plist

### DIFF
--- a/SimpleLogin/SimpleLogin/Info.plist
+++ b/SimpleLogin/SimpleLogin/Info.plist
@@ -34,7 +34,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSFaceIDUsageDescription</key>
-	<string>Restrict unwelcome access to your SimpleLogin account on this device</string>
+	<string>Restrict unwelcome access to your SimpleLogin application on this device</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>SimpleLogin needs photo library access to update your profile photo</string>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### Summary:

Refer the PR https://github.com/simple-login/Simple-Login-iOS/pull/159 that update the "Privacy - Face ID Usage Description" message from plist file.

### Modifications:

+ SimpleLogin/SimpleLogin/Info.plist

### Result:

Replace "Restrict unwelcome access to your SimpleLogin **account** on this device" with "Restrict unwelcome access to your SimpleLogin **application** on this device"
